### PR TITLE
ENHANCED: Better error handling if Type is invalid.

### DIFF
--- a/src/prolog/lib/error.pl
+++ b/src/prolog/lib/error.pl
@@ -27,8 +27,8 @@
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 must_be(Type, Term) :-
+        must_be_(type, Type),
         must_be_(Type, Term).
-
 
 must_be_(Type, _) :-
         var(Type),
@@ -36,6 +36,7 @@ must_be_(Type, _) :-
 must_be_(integer, Term) :- check_(integer, integer, Term).
 must_be_(atom, Term)    :- check_(atom, atom, Term).
 must_be_(list, Term)    :- check_(ilist, list, Term).
+must_be_(type, Term)    :- check_(type, type, Term).
 
 check_(Pred, Type, Term) :-
         (   var(Term) -> instantiation_error(Term)
@@ -47,6 +48,10 @@ ilist(V) :- var(V), instantiation_error(V).
 ilist([]).
 ilist([_|Ls]) :- ilist(Ls).
 
+type(type).
+type(integer).
+type(atom).
+type(list).
 
 /* - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    can_be(Type, Term)
@@ -63,6 +68,7 @@ ilist([_|Ls]) :- ilist(Ls).
 
 
 can_be(Type, Term) :-
+        must_be(type, Type),
         (   var(Term) -> true
         ;   can_(Type, Term) -> true
         ;   type_error(Type, Term)


### PR DESCRIPTION
Strictly speaking, type is currently not a type, so a domain error is
appropriate if Type is not a valid type. However, there are also other
cases where new types have been introduced in the past, and this
seems a good candidate for a new type. Let us hence use a type error.

Example:

    ?- can_be(listi, [a,b|Ls]).
    %@ ERROR: Type error: `type' expected, found `listi' (an atom)